### PR TITLE
Dockerize Kirppu

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*.pyc
+*.mo
+/static/
+kirppu/local_settings.py
+kirppu_project/local_settings.py
+node_modules
+/KirppuVenv*/
+kirppu/static/kirppu/*
+kirppu/static_src/js/api_stub.js
+*.sqlite3
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules
 /KirppuVenv*/
 kirppu/static/kirppu/*
 kirppu/static_src/js/api_stub.js
+*.sqlite3
+.vscode/

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -79,9 +79,12 @@ Successfully installed django-1.6.10 django-pipeline-1.3.27 pillow-2.4.0 pyBarco
 
 ### Add some example Data for Kirppu.
 ```Text
+# Avoid having to define SECRET_KEY & co
+(venv) ~/kirppu$ export DEBUG=1
+
 # Initialize models for Kirppu in a sqlite database (db.sqlite).
 # Create a new superuser when asked.
-(venv) ~/kirppu$ python manage.py syncdb
+(venv) ~/kirppu$ python manage.py migrate
 Installed 0 object(s) from 0 fixture(s)
 
 # Load some fake data to play with.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:2.7
+WORKDIR /usr/src/app
+
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    apt-get -y install nodejs && \
+    mkdir -p /usr/src/app/kirppu
+
+COPY requirements.txt requirements-oauth.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt -r requirements-oauth.txt
+
+COPY . /usr/src/app
+RUN cd /usr/src/app/kirppu && \
+    npm install && \
+    npm run gulp && \
+    rm -rf node_modules && \
+    groupadd -r kirppu && useradd -r -g kirppu kirppu
+
+RUN env DEBUG=1 python manage.py collectstatic --noinput && \
+    python -m compileall -q .
+
+USER kirppu
+EXPOSE 8000
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN env DEBUG=1 python manage.py collectstatic --noinput && \
 
 USER kirppu
 EXPOSE 8000
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["python", "manage.py", "docker_start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
     apt-get -y install nodejs && \
     mkdir -p /usr/src/app/kirppu
 
-COPY requirements.txt requirements-oauth.txt /usr/src/app/
-RUN pip install --no-cache-dir -r requirements.txt -r requirements-oauth.txt
+COPY requirements.txt requirements-oauth.txt requirements-production.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt -r requirements-oauth.txt -r requirements-production.txt
 
 COPY . /usr/src/app
 RUN cd /usr/src/app/kirppu && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,41 @@
+def image = "tracon/kirppu:build-${env.BUILD_NUMBER}"
+
+stage("Build") {
+  node {
+    checkout scm
+    sh "docker build --tag ${image} ."
+  }
+}
+
+// stage("Test") {
+//   node {
+//     sh """
+//       docker run \
+//         --rm \
+//         --link jenkins.tracon.fi-postgres:postgres \
+//         --env-file ~/.kirppu.env \
+//         ${image} \
+//         python manage.py test --keepdb
+//     """
+//   }
+// }
+
+stage("Push") {
+  node {
+    sh "docker tag ${image} tracon/kirppu:latest && docker push tracon/kirppu:latest && docker rmi ${image}"
+  }
+}
+
+stage("Deploy") {
+  node {
+    git url: "git@github.com:tracon/ansible-tracon"
+    sh """
+      ansible-playbook \
+        --vault-password-file=~/.vault_pass.txt \
+        --user root \
+        --limit neula.kompassi.eu \
+        --tags kirppu-deploy \
+        tracon.yml
+    """
+  }
+}

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -3,7 +3,7 @@ The MIT License (MIT)
 Copyright (c) 2013 Jyrki Launonen
 Copyright (c) 2014 Ari Koivula, Jyrki Launonen, Elina Lukkarinen, Arttu Ylä-Outinen
 Copyright (c) 2015 Mikko Karttunen, Ari Koivula, Aarni Koskela, Jyrki Launonen, Juha Lepola, Mikael Niemelä, Arttu Ylä-Outinen
-Copyright (c) 2014–2015 Santtu Pajukanta
+Copyright (c) 2014–2017 Santtu Pajukanta
 Copyright (c) 2016 Aarni Koskela, Jyrki Launonen
 Copyright (c) 2017 Jyrki Launonen
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Install Docker and `docker-compose` and run
 
     docker-compose up
 
-There is a race between the `postgres` and `web` containers and the first try will usually fail. Workaround is to Ctrl+C once the PostgreSQL database has initialized and then run `docker-compose up` again.
-
 ## Getting started without Docker
 
 This guide is meant for setting up a basic Kirppu development environment for testing.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
-# Setting up development environment
+# Kirppu – Second-hand sales POS and vendor signup for conventions
+
+## Getting started using Docker
+
+Install Docker and `docker-compose` and run
+
+    docker-compose up
+
+There is a race between the `postgres` and `web` containers and the first try will usually fail. Workaround is to Ctrl+C once the PostgreSQL database has initialized and then run `docker-compose up` again.
+
+## Getting started without Docker
+
 This guide is meant for setting up a basic Kirppu development environment for testing.
 It consists of a high level guide outlining the steps, example guide that has more detail and finally some pointers on how to access Kirppu once it's running.
 
 
-## High level guide
+### High level guide
 
 1. Install python.
     1. Install pip.
@@ -21,7 +32,7 @@ It consists of a high level guide outlining the steps, example guide that has mo
 9. Run django with manage.py.
 
 
-## Example guide
+### Example guide
 
 Windows:
 
@@ -36,7 +47,7 @@ Syntax:
 - \> Windows specific command line
 
 
-### Setting up Kirppu and its dependencies
+#### Setting up Kirppu and its dependencies
 ```Text
 # Install python if your system doesn't have it already.
 $ sudo aptitude install python
@@ -77,7 +88,7 @@ Successfully installed django-1.6.10 django-pipeline-1.3.27 pillow-2.4.0 pyBarco
 ~/kirppu/kirppu$ npm run gulp
 ```
 
-### Add some example Data for Kirppu.
+#### Add some example Data for Kirppu.
 ```Text
 # Avoid having to define SECRET_KEY & co
 (venv) ~/kirppu$ export DEBUG=1
@@ -95,7 +106,7 @@ Installed 10 object(s) from 1 fixture(s)
 (venv) ~/kirppu$ python manage.py runserver 9874
 ```
 
-## Testing Kirppu
+### Testing Kirppu
 
 - Admin interface
     - `localhost:9874/admin/`
@@ -154,3 +165,34 @@ To compile frontend sources for use in browser, there is two choices, which can 
 - "Rebuild production":
     - Same as above, but this additionally compress the results (of some parts). This will take a bit longer than without compress.
     - Arguments: `--type production`
+
+
+## MIT License
+
+    The MIT License (MIT)
+
+    Copyright (c) 2013 Jyrki Launonen
+    Copyright (c) 2014 Ari Koivula, Jyrki Launonen, Elina Lukkarinen, Arttu Ylä-Outinen
+    Copyright (c) 2015 Mikko Karttunen, Ari Koivula, Aarni Koskela, Jyrki Launonen, Juha Lepola, Mikael Niemelä, Arttu Ylä-Outinen
+    Copyright (c) 2014–2017 Santtu Pajukanta
+    Copyright (c) 2016 Aarni Koskela, Jyrki Launonen
+    Copyright (c) 2017 Jyrki Launonen
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   web:
     build: .
-    command: python manage.py docker_start
+    command: scripts/wait-for-it.sh postgres:5432 -- python manage.py docker_start
     ports:
       - 8000:8000
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '2'
+services:
+  web:
+    build: .
+    command: python manage.py runserver 0.0.0.0:8000
+    ports:
+      - 8000:8000
+    links:
+      - postgres
+    volumes:
+      - .:/usr/src/app
+    environment:
+      DEBUG: 1
+      DATABASE_URL: psql://kirppu:secret@postgres/kirppu
+      ALLOWED_HOSTS: '*'
+  postgres:
+    image: postgres
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: kirppu
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: kirppu
+volumes:
+  postgres-data:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   web:
     build: .
-    command: python manage.py runserver 0.0.0.0:8000
+    command: python manage.py docker_start
     ports:
       - 8000:8000
     links:

--- a/kirppu/management/commands/docker_start.py
+++ b/kirppu/management/commands/docker_start.py
@@ -1,0 +1,52 @@
+# encoding: utf-8
+
+import logging
+
+from django.conf import settings
+from django.db import ProgrammingError
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    args = ''
+    help = 'Docker development environment entry point'
+
+    def handle(self, *args, **options):
+        from ...models import Clerk
+
+        test = settings.DEBUG
+
+        if not test:
+            raise ValueError('Should run with DEBUG=true')
+
+        try:
+            Clerk.objects.first()
+        except ProgrammingError:
+            call_command('migrate')
+
+            user, created = get_user_model().objects.get_or_create(
+                username='mahti',
+                defaults=dict(
+                    is_superuser=True,
+                    is_staff=True,
+                    first_name='Markku',
+                    last_name='Mahtinen',
+                    email='mahti@example.com',
+                ),
+            )
+
+            logger.log(
+                logging.WARN if created else logging.DEBUG,
+                'User %s %s',
+                user,
+                'created' if created else 'already exists'
+            )
+
+            call_command('loaddata', 'dev_data')
+
+        call_command('runserver', '0.0.0.0:8000')

--- a/kirppu_project/settings.py
+++ b/kirppu_project/settings.py
@@ -4,26 +4,27 @@ from __future__ import unicode_literals, print_function, absolute_import
 import os.path
 from django.utils.translation import ugettext_lazy as _
 
-BASE = os.path.dirname(os.path.abspath(__file__))
-_path = lambda path: os.path.normpath(os.path.join(BASE, '..', path))
+import environ
 
-DEBUG = True
+
+env = environ.Env()
+
+BASE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _path(path):
+    return os.path.normpath(os.path.join(BASE, '..', path))
+
+
+DEBUG = env.bool('DEBUG', default=False)
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',  # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': _path('db.sqlite'),              # Or path to database file if using sqlite3.
-        # The following settings are not used with sqlite3:
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': '',  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        'PORT': '',  # Set to empty string for default.
-    }
+    'default': env.db(default='sqlite:///db.sqlite3'),
 }
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = env('ALLOWED_HOSTS', default='').split()
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -90,7 +91,9 @@ STATICFILES_FINDERS = (
 )
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = '=#j)-ml7x@a2iw9=#l7%i89l%cry6kch6x49=0%vcasq!!@97-'
+SECRET_KEY = env.str('SECRET_KEY', default=(
+    '' if not DEBUG else '=#j)-ml7x@a2iw9=#l7%i89l%cry6kch6x49=0%vcasq!!@97-'
+))
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -204,17 +207,34 @@ KOMPASSI_USER_MAP_V2 = [
     ('phone', 'phone'),
 ]
 
-KOMPASSI_API_URL = 'http://kompassi.dev:8001/api/v1'
-KOMPASSI_API_APPLICATION_NAME = 'kirppu'
-KOMPASSI_API_APPLICATION_PASSWORD = 'fill me in'
+KOMPASSI_API_APPLICATION_NAME = env(
+    'KOMPASSI_API_APPLICATION_NAME',
+    default='kirppu',
+)
+KOMPASSI_API_APPLICATION_PASSWORD = env(
+    'KOMPASSI_API_APPLICATION_PASSWORD',
+    default='fill me in',
+)
 
-KOMPASSI_OAUTH2_AUTHORIZATION_URL = 'http://kompassi.dev:8001/oauth2/authorize'
-KOMPASSI_OAUTH2_TOKEN_URL = 'http://kompassi.dev:8001/oauth2/token'
-KOMPASSI_OAUTH2_REVOKE_URL = 'http://kompassi.dev:8001/oauth2/revoke'
-KOMPASSI_OAUTH2_CLIENT_ID = 'kompassi_insecure_test_client_id'
-KOMPASSI_OAUTH2_CLIENT_SECRET = 'kompassi_insecure_test_client_secret'
+KOMPASSI_HOST = KOMPASSI_API_URL = env('KOMPASSI_HOST', default='https://kompassi.eu')
+KOMPASSI_OAUTH2_AUTHORIZATION_URL = '{KOMPASSI_HOST}/oauth2/authorize'.format(**locals())
+KOMPASSI_OAUTH2_TOKEN_URL = '{KOMPASSI_HOST}/oauth2/token'.format(**locals())
+
+KOMPASSI_OAUTH2_CLIENT_ID = env(
+    'KOMPASSI_OAUTH2_CLIENT_ID',
+    default='kompassi_insecure_test_client_id',
+)
+
+KOMPASSI_OAUTH2_CLIENT_SECRET = env(
+    'KOMPASSI_OAUTH2_CLIENT_SECRET',
+    default='kompassi_insecure_test_client_secret'
+)
+
 KOMPASSI_OAUTH2_SCOPE = ['read']
-KOMPASSI_API_V2_USER_INFO_URL = 'http://kompassi.dev:8001/api/v2/people/me'
+KOMPASSI_API_V2_USER_INFO_URL = '{KOMPASSI_HOST}/api/v2/people/me'.format(**locals())
+KOMPASSI_API_V2_EVENT_INFO_URL_TEMPLATE = '{kompassi_host}/api/v2/events/{event_slug}'
+KOMPASSI_ADMIN_GROUP = env('KOMPASSI_ADMIN_GROUP', default='admins')
+
 
 # Kirppu authentication configurations:
 #
@@ -232,16 +252,17 @@ KOMPASSI_API_V2_USER_INFO_URL = 'http://kompassi.dev:8001/api/v2/people/me'
 # LOGIN_URL = '/oauth2/login'
 
 # Absolute URL for user "Profile". Leave None if the link should not be displayed.
-PROFILE_URL = None  # 'https://kompassidev.tracon.fi/profile'
+# 'https://kompassidev.tracon.fi/profile'
+PROFILE_URL = env('KOMPASSI_PROFILE_URL', default=None)
 
 # Whether external login and SSO clerk add are enabled (True) or not (False).
-KIRPPU_USE_SSO = False
+KIRPPU_USE_SSO = env.bool('KIRPPU_USE_SSO', default=False)
 
 # If True, admin can change identity.
 KIRPPU_SU_AS_USER = "kirppuauth" in INSTALLED_APPS
 
 # Whether checkout functionality is active or not.
-KIRPPU_CHECKOUT_ACTIVE = False
+KIRPPU_CHECKOUT_ACTIVE = env.bool('KIRPPU_CHECKOUT_ACTIVE', default=False)
 
 # Automatic checkout login. May not be enabled in non-dev environments!
 # If True, first enabled Clerk is automatically used.

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -1,0 +1,2 @@
+gunicorn~=19.6.0
+psycopg2~=2.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
+django-environ~=0.4.0
 django>=1.8.11,<1.10
 pillow<3.3
-pytz>=2013d
 pubcode>=1.1.0
+pytz>=2013d

--- a/scripts/wait-for-it.sh
+++ b/scripts/wait-for-it.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# https://github.com/vishnubob/wait-for-it
+#   Use this script to test if a given TCP host/port are available
+#
+# The MIT License (MIT)
+# Copyright (c) 2016 Giles Hall
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI="$@"
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec $CLI
+else
+    exit $RESULT
+fi


### PR DESCRIPTION
Make Kirppu run on Docker for deployment on [5th Generation Tracon Infrastructure](https://github.com/tracon/ansible-tracon).

Changes affecting the Kirppu repository:

- [x] make Kirppu configurable using environment variables, see https://12factor.net/config
- [x] create `Dockerfile`
- [x] create hands-free `python manage.py docker_start` script for setting up development environment
- [x] create `docker-compose.yml` for development
- [ ] move master copy of the Kirppu git repository under github.com/tracon

Changes outside the Kirppu repository:

- [ ] in hub.docker.com/r/tracon, add a repository for Kirppu
- [ ] in jenkins.tracon.fi, create a build for Kirppu
- [ ] in github.com/tracon/ansible-tracon, create a role for Kirppu and add the said role to nuoli.tracon.fi