### PR TITLE
Test using py.test and Travis

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+#branch = True
+omit =
+    *management/commands*
+    *migrations*
+    */wsgi.py
+    manage.py

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ kirppu/static/kirppu/*
 kirppu/static_src/js/api_stub.js
 *.sqlite3
 .vscode/
+.cache
+htmlcov
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: python
+env:
+  DEBUG: 1
+  SECRET_KEY: 'x'
+  ALLOWED_HOSTS: '*'
+  KIRPPU_CHECKOUT_ACTIVE: true
+python: "3.5"
+install:
+  - pip install -r requirements.txt
+  - pip install -r requirements-oauth.txt
+  - pip install -r requirements-dev.txt
+script:
+  - py.test -vvv --cov . --doctest-modules
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ stage("Build") {
 //         --link jenkins.tracon.fi-postgres:postgres \
 //         --env-file ~/.kirppu.env \
 //         ${image} \
-//         python manage.py test --keepdb
+//         pip install -r requirements-dev.txt && py.test --cov . --doctest-modules
 //     """
 //   }
 // }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It consists of a high level guide outlining the steps, example guide that has mo
 
 ### High level guide
 
-1. Install python.
+1. Install Python 3.4+.
     1. Install pip.
        Pip is used for downloading and installing dependencies. It is included
        by default in Python since 2.7.9 and 3.4.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ Installed 10 object(s) from 1 fixture(s)
 
 ### Testing Kirppu
 
+Install the dependencies from `requirements-dev.txt`.
+You can then run unit tests with
+
+```
+py.test -vvv --cov . --doctest-modules
+```
+
 - Admin interface
     - `localhost:9874/admin/`
     - Login with the local superuser credentials.

--- a/kirppu/tests/api_access.py
+++ b/kirppu/tests/api_access.py
@@ -24,7 +24,10 @@ class Api(object):
             self._end_points[name] = gen(func.method.lower(), func.view)
 
     def __getattr__(self, function):
+        if function == '__wrapped__':  # Placate inspect.is_wrapper
+            return False
         return self._end_points[function]
+
 
 api = Api(False)
 api.__doc__ = "Checkout Api request handler."

--- a/kirppu_project/test/test_doctests.py
+++ b/kirppu_project/test/test_doctests.py
@@ -1,9 +1,0 @@
-import doctest
-
-from kirppu import util, models
-
-
-def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(util))
-    tests.addTests(doctest.DocTestSuite(models))
-    return tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,5 @@
 factory-boy>=2.8.1,<2.9
+pytest
+pytest-django
+pytest-env
+pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,32 @@
+[tool:pytest]
+addopts = --tb=short
+norecursedirs = bower_components node_modules .git venv
+DJANGO_SETTINGS_MODULE = kirppu_project.settings
+env =
+	KIRPPU_CHECKOUT_ACTIVE=true
+
+[pep8]
+max-line-length = 120
+exclude =*migrations*,*node_modules*
+ignore = E309
+
+[flake8]
+exclude = .tox,migrations,doc/*,venv/*
+max-line-length = 120
+max-complexity = 10
+
+[isort]
+atomic = true
+combine_as_imports = false
+indent = 4
+known_standard_library = token,tokenize,enum,importlib
+known_third_party = django,six
+length_sort = false
+line_length = 120
+multi_line_output = 5
+not_skip = __init__.py
+order_by_type = false
+skip =
+    migrations
+    node_modules
+wrap_length = 120


### PR DESCRIPTION
This PR adds pytest and pytest-django for convenient test running.

It also adds .travis.yml, so Travis CI and Codecov can be set up (free for open source projects!) to do CI.

Coverage seems to be at around 55% at present.