### PR TITLE
Un-ancientize Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ django-environ~=0.4.0,!=0.4.2
 django-ipware~=1.1.6
 django-ratelimit~=1.0.1
 django>=1.11,<1.12
-pillow<3.3
+pillow~=5.0.0
 pubcode>=1.1.0
 pytz>=2013d


### PR DESCRIPTION
Kirppu certifiably works with Pillow 5.0, so let's use it!

(The installation we have over at Desucon has problems with the old Pillow, so I always need to upgrade it after `pip install` downgrades it. :sweat_smile:)