### PR TITLE
Require a setting to enable running arbitrary provision function code

### DIFF
--- a/kirppu/provision.py
+++ b/kirppu/provision.py
@@ -4,6 +4,8 @@ from decimal import Decimal
 from typing import Optional
 
 import django.db.models
+from django.conf import settings
+from django.core.exceptions import SuspiciousOperation
 from django.db.models import Sum, Q
 
 from .models import ReceiptExtraRow, Receipt, Item, ReceiptItem
@@ -67,6 +69,8 @@ class Provision(object):
     def run_function(cls, provision_function, sold_and_compensated) -> Optional[Decimal]:
         if provision_function is None or provision_function == "":
             return None
+        if not getattr(settings, "KIRPPU_ALLOW_PROVISION_FUNCTIONS", False):
+            raise SuspiciousOperation("Provision functions are not allowed.")
 
         builtins_copy = {k: getattr(builtins, k) for k in dir(builtins) if k not in (
             "eval", "exec", "open", "__import__"

--- a/kirppu/tests/test_provision.py
+++ b/kirppu/tests/test_provision.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import textwrap
 
-from django.test import Client
+from django.test import Client, override_settings
 from django.test import TestCase
 
 from kirppu.provision import Provision
@@ -29,6 +29,7 @@ class SoldItemFactory(ItemFactory):
     state = Item.SOLD
 
 
+@override_settings(KIRPPU_ALLOW_PROVISION_FUNCTIONS=True)
 class ProvisionTest(TestCase):
     def setUp(self):
         self.vendor = VendorFactory()
@@ -58,6 +59,7 @@ class ProvisionTest(TestCase):
         # FIXME: Failing. This should be either None/0 or -1, but which?"""
 
 
+@override_settings(KIRPPU_ALLOW_PROVISION_FUNCTIONS=True)
 class BeforeProvisionTest(TestCase):
     def setUp(self):
         self.vendor = VendorFactory()
@@ -89,6 +91,7 @@ class BeforeProvisionTest(TestCase):
         self.assertEqual(p.provision, Decimal("-1.00"))
 
 
+@override_settings(KIRPPU_ALLOW_PROVISION_FUNCTIONS=True)
 class FinishingProvisionTest(TestCase):
     def setUp(self):
         self.vendor = VendorFactory()
@@ -175,6 +178,7 @@ class _ApiMixin(object):
         return extras
 
 
+@override_settings(KIRPPU_ALLOW_PROVISION_FUNCTIONS=True)
 class ApiNoProvisionTest(_ApiMixin, TestCase):
 
     # region No Provision
@@ -199,6 +203,7 @@ class ApiNoProvisionTest(_ApiMixin, TestCase):
     # endregion
 
 
+@override_settings(KIRPPU_ALLOW_PROVISION_FUNCTIONS=True)
 class ApiLinearProvisionTest(_ApiMixin, TestCase):
     def _setUp_Event(self):
         self.event = EventFactory(
@@ -231,6 +236,7 @@ class ApiLinearProvisionTest(_ApiMixin, TestCase):
     # endregion
 
 
+@override_settings(KIRPPU_ALLOW_PROVISION_FUNCTIONS=True)
 class ApiStepProvisionTest(_ApiMixin, TestCase):
     def _setUp_Event(self):
         self.event = EventFactory(
@@ -265,6 +271,7 @@ class ApiStepProvisionTest(_ApiMixin, TestCase):
     # endregion
 
 
+@override_settings(KIRPPU_ALLOW_PROVISION_FUNCTIONS=True)
 class ApiRoundingProvisionTest(_ApiMixin, TestCase):
     def _setUp_Event(self):
         self.event = EventFactory(


### PR DESCRIPTION
The sandbox for `Provision.run_function()` is rather easily circumvented (inquire within for details).

For installations such as Desucon's, where we don't need provision functions at all, this disables the provision function system altogether to avoid inadvertent remote code execution.

Handily, since `_validate_provision_function()` catches all exceptions, `SuspiciousOperation` included, an user attempting to enter provision function code will get the same error the actual provision call would.