### PR TITLE
Don't crash if someone enters a non-integer box_number

### DIFF
--- a/kirppu/checkout_api.py
+++ b/kirppu/checkout_api.py
@@ -289,7 +289,10 @@ def item_search(request, event, query, code, box_number, vendor, min_price, max_
         clauses.append(Q(code__contains=code))
 
     if box_number:
-        clauses.append(Q(box__box_number=int(box_number)))
+        try:
+            clauses.append(Q(box__box_number=int(box_number)))
+        except ValueError:
+            pass
 
     if vendor:
         clauses.append(Q(vendor=vendor))


### PR DESCRIPTION
According to Desucon's Sentry, someone (repeatedly) entered "box102", which caused a 500 Infernal Server Terror.